### PR TITLE
Improve docs and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS: [e.g. Ubuntu 22.04]
+- Python version: [e.g. 3.10]
+- Additional context
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # skill-atlas
-Procedural skill-atlas generator
 
+A playground for experimenting with **procedural skill-tree generation**. The project aims to create a flexible graph composition engine where nodes can be expanded into subgraphs according to a set of rewrite rules. Everything is still in the planning stages, but this repository documents the intended layout and upcoming milestones.
 
+## Repository layout
+
+```
 skill-atlas/
 ├─ README.md              ← Project pitch, quick-start, and architecture overview
 ├─ LICENSE                ← Pick your poison (MIT / Apache-2.0 are friendly)
@@ -63,3 +66,16 @@ skill-atlas/
    ├─ unit/
    ├─ integration/
    └─ golden/            – fixtures for deterministic graph snapshots
+```
+
+## Graph composition model
+
+At its heart the project treats a skill tree as a directed acyclic graph. Nodes can represent talents, perks, or technology items. Each node may optionally reference another graph template. During generation the **generator** module walks the graph, substituting these templates according to a set of procedural rules. This allows small building blocks to be combined into large atlases without hand‑crafting every connection.
+
+Rules live in the `grammar` package and describe how patterns should be replaced or expanded. A simple example might replace a single "spell" node with a small spell school subgraph, rolled with weighted randomness. More sophisticated rules can cluster nodes, mirror whole sections, or mutate attributes.
+
+The end goal is a reusable toolkit that can output to multiple formats (JSON, Godot scenes, Unity YAML, etc.) after applying a layout algorithm. The current codebase only contains the scaffolding, but the plan is laid out in the source tree and `ROADMAP.md`.
+
+## Contributing
+
+Contributions are welcome! Check the issue templates for guidance on filing bugs or proposing features. The [Roadmap](./ROADMAP.md) lists a few of the high‑level tasks that still need volunteers.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+This file captures outstanding tasks and ideas for future contributors. When submitting new issues or PRs, reference the relevant checklist item below.
+
+## Core modules
+- [ ] Implement graph primitives (`Node`, `Edge`, `Graph`)
+- [ ] Add rule parser and standard rule library
+- [ ] Build the composition engine that expands subgraphs into nodes
+
+## CLI and examples
+- [ ] Create a minimal CLI for generating an atlas from a config file
+- [ ] Provide example configurations under `examples/`
+
+## Layout and export
+- [ ] Implement radial and force-directed layout algorithms
+- [ ] Provide exporters for JSON and a basic HTML visualization
+
+Feel free to add more tasks or expand the descriptions as the project evolves.


### PR DESCRIPTION
## Summary
- expand README with overview and graph composition notes
- add issue templates for bugs and features
- add a roadmap for contributors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd3e5c5288333b7ef6c92b6876e95