### PR TITLE
Add Path of Exile skill node example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+This directory contains sample data and scripts demonstrating how to work with skill node data. `path_of_exile_nodes.json` was generated from the official [Path of Exile skill tree export](https://github.com/grindinggear/skilltree-export) and includes a few sample nodes. `poe_nodes_example.py` shows how to load the JSON into a Python dictionary.

--- a/examples/path_of_exile_nodes.json
+++ b/examples/path_of_exile_nodes.json
@@ -1,0 +1,63 @@
+{
+  "10031": {
+    "skill": 10031,
+    "name": "Life",
+    "icon": "Art/2DArt/SkillIcons/passives/life1.png",
+    "stats": [
+      "6% increased maximum Life"
+    ],
+    "group": 84,
+    "orbit": 2,
+    "orbitIndex": 4,
+    "out": [
+      "15064"
+    ],
+    "in": [
+      "36949"
+    ]
+  },
+  "10016": {
+    "skill": 10016,
+    "name": "Executioner",
+    "icon": "Art/2DArt/SkillIcons/passives/reaver.png",
+    "isNotable": true,
+    "recipe": [
+      "AmberOil",
+      "VerdantOil",
+      "AzureOil"
+    ],
+    "stats": [
+      "60% increased Damage with Hits against Enemies that are on Low Life",
+      "15% increased Area of Effect if you've Killed Recently"
+    ],
+    "reminderText": [
+      "(Recently refers to the past 4 seconds)"
+    ],
+    "group": 261,
+    "orbit": 3,
+    "orbitIndex": 11,
+    "out": [
+      "35118"
+    ],
+    "in": [
+      "35362"
+    ]
+  },
+  "10017": {
+    "skill": 10017,
+    "name": "Attack Speed",
+    "icon": "Art/2DArt/SkillIcons/passives/attackspeed.png",
+    "stats": [
+      "4% increased Attack Speed"
+    ],
+    "group": 517,
+    "orbit": 2,
+    "orbitIndex": 8,
+    "out": [
+      "38344"
+    ],
+    "in": [
+      "65033"
+    ]
+  }
+}

--- a/examples/poe_nodes_example.py
+++ b/examples/poe_nodes_example.py
@@ -1,0 +1,14 @@
+"""Example script demonstrating a small set of Path of Exile skill nodes."""
+import json
+from pathlib import Path
+
+# Load nodes from the adjacent JSON file
+with Path(__file__).with_name("path_of_exile_nodes.json").open() as f:
+    POE_NODES = json.load(f)
+
+if __name__ == "__main__":
+    for node_id, data in POE_NODES.items():
+        print(f"{node_id}: {data['name']}")
+        for stat in data.get("stats", []):
+            print(f"  - {stat}")
+


### PR DESCRIPTION
## Summary
- add `examples/` with a sample JSON file of Path of Exile skill nodes
- include a Python script showing how to load that data
- document the new example

## Testing
- `pip install -e .`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684df2406a848333845b8e0eeb9c580f