### PR TITLE
Add linting, typing and coverage CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,17 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
       - run: |
-          pip install -e .
-          pip install pytest
-          pytest
+          pip install -e .[dev]
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: pyright
+      - run: pytest --cov=skill_atlas --cov-report=term-missing --cov-fail-under=80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: check
+check:
+	pre-commit run --all-files

--- a/examples/poe_nodes_example.py
+++ b/examples/poe_nodes_example.py
@@ -1,4 +1,5 @@
 """Example script demonstrating a small set of Path of Exile skill nodes."""
+
 import json
 from pathlib import Path
 
@@ -11,4 +12,3 @@ if __name__ == "__main__":
         print(f"{node_id}: {data['name']}")
         for stat in data.get("stats", []):
             print(f"  - {stat}")
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,24 @@ requires-python = ">=3.9"
 
 dependencies = ["networkx>=3.0"]
 
+[project.optional-dependencies]
+dev = [
+    "pre-commit",
+    "ruff",
+    "pyright",
+    "pytest",
+    "pytest-cov",
+]
+
 [project.scripts]
 skill-atlas = "skill_atlas.cli.main:run"
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+
+[tool.pyright]
+typeCheckingMode = "strict"

--- a/src/skill_atlas/cli/main.py
+++ b/src/skill_atlas/cli/main.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
+from typing import Any
+
 import networkx as nx
 
 
-def build_graph(n: int) -> nx.Graph:
+def build_graph(n: int) -> nx.Graph[Any]:
     """Return a simple graph with ``n`` nodes."""
-    g = nx.Graph()
-    g.add_nodes_from(range(n))
+    g: nx.Graph[Any] = nx.Graph()
+    g.add_nodes_from(range(n))  # pyright: ignore[reportUnknownMemberType]
     return g
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
+import pytest
+
 from skill_atlas.cli.main import run
 
 
-def test_cli_runs(capsys):
+def test_cli_runs(capsys: pytest.CaptureFixture[str]) -> None:
     run(["--nodes", "2"])
     captured = capsys.readouterr()
     assert "generated graph with 2 nodes" in captured.out


### PR DESCRIPTION
## Summary
- add dev dependencies and tool configs for Black, Ruff and Pyright
- add pre-commit and `make check`
- enforce formatting and typing in CI
- annotate code for Pyright strict mode
- keep example formatted

## Testing
- `pre-commit run --all-files`
- `pytest --cov=skill_atlas --cov-report=term-missing --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_e_684dffebf9a08333b7f44a64f1eec4a0