### PR TITLE
Implement AtlasGraph wrapper

### DIFF
--- a/src/skill_atlas/core/__init__.py
+++ b/src/skill_atlas/core/__init__.py
@@ -1,0 +1,4 @@
+from .node import Node, Edge
+from .graph import AtlasGraph
+
+__all__ = ["Node", "Edge", "AtlasGraph"]

--- a/src/skill_atlas/core/graph.py
+++ b/src/skill_atlas/core/graph.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from attrs import define, field
+import json
+import networkx as nx
+from typing import Any
+
+from .node import Edge, Node
+
+
+def _graph_factory() -> nx.MultiDiGraph[Any]:
+    return nx.MultiDiGraph()
+
+
+@define(slots=True)
+class AtlasGraph:
+    """Immutable wrapper around ``networkx.MultiDiGraph``."""
+
+    _g: nx.MultiDiGraph[Any] = field(factory=_graph_factory)
+    _edges: list[Edge] = field(factory=lambda: [], init=False)
+
+    # ------------------------------------------------------------------
+    def add_node(self, node: Node) -> None:
+        """Add ``node`` to the graph."""
+        self._g.add_node(node.id, node=node)  # pyright: ignore[reportUnknownMemberType]
+
+    # ------------------------------------------------------------------
+    def add_edge(self, edge: Edge) -> None:
+        """Add ``edge`` to the graph."""
+        self._g.add_edge(edge.tail, edge.head, edge=edge)  # pyright: ignore[reportUnknownMemberType]
+        if not edge.directed:
+            self._g.add_edge(edge.head, edge.tail, edge=edge)  # pyright: ignore[reportUnknownMemberType]
+        self._edges.append(edge)
+
+    # ------------------------------------------------------------------
+    def nodes(self) -> list[Node]:
+        node_items = list(self._g.nodes(data=True))
+        node_items_sorted: list[tuple[str, dict[str, Any]]] = sorted(node_items)
+        return [data["node"] for _, data in node_items_sorted]
+
+    # ------------------------------------------------------------------
+    def edges(self) -> list[Edge]:
+        return list(self._edges)
+
+    # ------------------------------------------------------------------
+    @property
+    def is_directed(self) -> bool:
+        return any(edge.directed for edge in self.edges())
+
+    # ------------------------------------------------------------------
+    def serialize(self) -> str:
+        graph_dict = {
+            "nodes": [
+                {
+                    "id": n.id,
+                    "name": n.name,
+                    "description": n.description,
+                    "icon_path": n.icon_path,
+                    "payload": n.payload,
+                }
+                for n in self.nodes()
+            ],
+            "edges": [
+                {
+                    "head": e.head,
+                    "tail": e.tail,
+                    "directed": e.directed,
+                    "payload": e.payload,
+                }
+                for e in self.edges()
+            ],
+        }
+        return json.dumps(graph_dict, sort_keys=True)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_json(cls, data: str) -> "AtlasGraph":
+        d: dict[str, Any] = json.loads(data)
+        g = cls()
+        for node_info in sorted(d["nodes"], key=lambda n: n["id"]):
+            g.add_node(
+                Node(
+                    id=node_info["id"],
+                    name=node_info["name"],
+                    description=node_info["description"],
+                    icon_path=node_info.get("icon_path"),
+                    payload=node_info.get("payload", {}),
+                )
+            )
+        for edge_info in d["edges"]:
+            g.add_edge(
+                Edge(
+                    head=edge_info["head"],
+                    tail=edge_info["tail"],
+                    directed=edge_info.get("directed", False),
+                    payload=edge_info.get("payload", {}),
+                )
+            )
+        return g
+
+    # ------------------------------------------------------------------
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, AtlasGraph):
+            return False
+        return self.serialize() == other.serialize()

--- a/tests/test_core_graph.py
+++ b/tests/test_core_graph.py
@@ -1,0 +1,13 @@
+from skill_atlas.core import AtlasGraph, Node, Edge
+
+
+def test_graph_round_trip() -> None:
+    g = AtlasGraph()
+    g.add_node(Node(id="a", name="A", description=""))
+    g.add_node(Node(id="b", name="B", description=""))
+    g.add_edge(Edge(head="b", tail="a", directed=True))
+
+    json_str = g.serialize()
+    new_g = AtlasGraph.from_json(json_str)
+    assert g == new_g
+    assert new_g.is_directed


### PR DESCRIPTION
## Summary
- add `AtlasGraph` wrapper around `networkx.MultiDiGraph`
- re-export `AtlasGraph` via `core.__init__`
- test graph round trip serialization

## Testing
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e14af69208333927ee4a3e6156ffd