### PR TITLE
Implement abstract node support

### DIFF
--- a/src/skill_atlas/core/node.py
+++ b/src/skill_atlas/core/node.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from attrs import define, field
-from typing import Any
+from typing import Any, Set
 
 
 def _payload_factory() -> dict[str, Any]:
@@ -17,6 +17,20 @@ class Node:
     description: str
     icon_path: str | None = None
     payload: dict[str, Any] = field(factory=_payload_factory, hash=False)
+
+    # ------------------------------------------------------------------
+    def is_abstract(self) -> bool:
+        """Return ``True`` if this node is marked as abstract."""
+
+        return bool(self.payload.get("abstract", False))
+
+    # ------------------------------------------------------------------
+    def matches(self, tags: Set[str]) -> bool:
+        """Return ``True`` if this node matches ``tags``."""
+
+        node_tags = set(self.payload.get("tags", []))
+        node_tags.update({"abstract" if self.is_abstract() else "concrete"})
+        return tags.issubset(node_tags)
 
 
 @define(frozen=True, slots=True)

--- a/tests/test_core_graph.py
+++ b/tests/test_core_graph.py
@@ -11,3 +11,16 @@ def test_graph_round_trip() -> None:
     new_g = AtlasGraph.from_json(json_str)
     assert g == new_g
     assert new_g.is_directed
+
+
+def test_graph_round_trip_with_abstract_node() -> None:
+    g = AtlasGraph()
+    g.add_node(Node(id="a", name="A", description="", payload={"abstract": True}))
+    g.add_node(Node(id="b", name="B", description=""))
+    g.add_edge(Edge(head="b", tail="a"))
+
+    json_str = g.serialize()
+    new_g = AtlasGraph.from_json(json_str)
+    assert g == new_g
+    abstract_nodes = [n for n in new_g.nodes() if n.is_abstract()]
+    assert len(abstract_nodes) == 1

--- a/tests/test_core_node.py
+++ b/tests/test_core_node.py
@@ -17,3 +17,24 @@ def test_edge_equality_and_hashing() -> None:
     assert edge1 == edge2
     assert hash(edge1) == hash(edge2)
     assert {edge1} == {edge2}
+
+
+def test_node_abstract_flag() -> None:
+    concrete = Node(id="c", name="C", description="")
+    abstract = Node(id="a", name="A", description="", payload={"abstract": True})
+
+    assert not concrete.is_abstract()
+    assert abstract.is_abstract()
+
+
+def test_node_matching() -> None:
+    node = Node(
+        id="m",
+        name="M",
+        description="",
+        payload={"abstract": True, "tags": ["foo", "bar"]},
+    )
+
+    assert node.matches({"foo"})
+    assert node.matches({"foo", "abstract"})
+    assert not node.matches({"baz"})


### PR DESCRIPTION
## Summary
- detect abstract nodes via payload tag
- add `Node.is_abstract()` and `Node.matches()` helpers
- exercise new behaviors in unit tests

## Testing
- `ruff check src tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1650fd1883339443c1b5df1d6fe3