### PR TITLE
Add rule DSL parser and docs

### DIFF
--- a/docs/rule_schema.md
+++ b/docs/rule_schema.md
@@ -1,0 +1,18 @@
+# Rule DSL
+
+Rules are described in YAML. Each rule defines:
+
+- `match`: list of tags that a node must contain to trigger the rule.
+- `replace`: subgraph inserted when the rule fires. It contains `nodes` and `edges` using the same fields as `AtlasGraph` JSON.
+- `probability`: optional float between 0 and 1 controlling how often the rule applies. Defaults to `1`.
+
+```yaml
+- match: [abstract, foo]
+  replace:
+    nodes:
+      - id: child
+        name: Child Node
+        description: Example node
+    edges: []
+  probability: 0.5
+```

--- a/examples/rules.yaml
+++ b/examples/rules.yaml
@@ -1,0 +1,18 @@
+- match: [abstract]
+  replace:
+    nodes:
+      - id: new1
+        name: New Node
+        description: Created from rule
+    edges: []
+- match: [foo, bar]
+  replace:
+    nodes:
+      - id: n2
+        name: Another Node
+        description: Example
+    edges:
+      - head: n2
+        tail: new1
+        directed: true
+  probability: 0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.9"
 dependencies = [
     "networkx>=3.0",
     "attrs>=23.1.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -19,6 +20,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "attrs>=23.1.0",
+    "PyYAML>=6.0",
 ]
 
 [project.scripts]

--- a/src/skill_atlas/grammar/__init__.py
+++ b/src/skill_atlas/grammar/__init__.py
@@ -1,0 +1,5 @@
+"""Grammar utilities for rule-based graph expansion."""
+
+from .rule import Rule, load_rules
+
+__all__ = ["Rule", "load_rules"]

--- a/src/skill_atlas/grammar/rule.py
+++ b/src/skill_atlas/grammar/rule.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from attrs import define
+from pathlib import Path
+from typing import Set
+import yaml
+
+from ..core import AtlasGraph, Node, Edge
+
+
+def _graph_from_dict(data: dict) -> AtlasGraph:
+    g = AtlasGraph()
+    for node_info in data.get("nodes", []):
+        g.add_node(
+            Node(
+                id=node_info["id"],
+                name=node_info["name"],
+                description=node_info.get("description", ""),
+                icon_path=node_info.get("icon_path"),
+                payload=node_info.get("payload", {}),
+            )
+        )
+    for edge_info in data.get("edges", []):
+        g.add_edge(
+            Edge(
+                head=edge_info["head"],
+                tail=edge_info["tail"],
+                directed=edge_info.get("directed", False),
+                payload=edge_info.get("payload", {}),
+            )
+        )
+    return g
+
+
+@define(slots=True)
+class Rule:
+    """Rewrite rule for expanding nodes."""
+
+    match: Set[str]
+    replace: AtlasGraph
+    probability: float = 1.0
+
+    # --------------------------------------------------------------
+    def applies(self, node: Node) -> bool:
+        """Return ``True`` if this rule can be applied to ``node``."""
+
+        return node.matches(self.match)
+
+    # --------------------------------------------------------------
+    def apply(self, graph: AtlasGraph, node_id: str, rng) -> AtlasGraph:
+        """Return replacement subgraph for ``node_id`` using ``rng`` for sampling."""
+
+        node = graph._g.nodes[node_id]["node"]  # pyright: ignore[reportPrivateUsage]
+        if not self.applies(node):
+            raise ValueError("rule does not apply to node")
+        if rng.random() > self.probability:
+            return AtlasGraph()
+        return AtlasGraph.from_json(self.replace.serialize())
+
+
+# --------------------------------------------------------------
+def load_rules(path: Path | str) -> list[Rule]:
+    """Load rules from a YAML file."""
+
+    p = Path(path)
+    data = yaml.safe_load(p.read_text()) or []
+    rules: list[Rule] = []
+    for r in data:
+        match = set(r.get("match", []))
+        replace = _graph_from_dict(r.get("replace", {}))
+        prob = float(r.get("probability", 1))
+        rules.append(Rule(match=match, replace=replace, probability=prob))
+    return rules

--- a/tests/test_grammar_rule.py
+++ b/tests/test_grammar_rule.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from skill_atlas.core import Node
+from skill_atlas.grammar import load_rules
+
+
+RULES_PATH = Path(__file__).resolve().parent.parent / "examples" / "rules.yaml"
+
+
+def test_load_rules() -> None:
+    rules = load_rules(RULES_PATH)
+    assert len(rules) == 2
+
+
+def test_rule_applies() -> None:
+    rules = load_rules(RULES_PATH)
+    rule = rules[0]
+    abstract_node = Node(id="a", name="A", description="", payload={"abstract": True})
+    concrete_node = Node(id="b", name="B", description="")
+
+    assert rule.applies(abstract_node)
+    assert not rule.applies(concrete_node)


### PR DESCRIPTION
## Summary
- define minimal YAML rule DSL and example file
- implement `grammar.Rule` with `applies`/`apply` and `load_rules`
- document rule schema
- test rule parsing and matching

## Testing
- `ruff check src tests`
- `pytest -q`

Labels: area:grammar

------
https://chatgpt.com/codex/tasks/task_e_684eab0b41808333bf4f0c23878fd177