### PR TITLE
Resolve issue #10: deterministic edge ordering

### DIFF
--- a/src/skill_atlas/core/graph.py
+++ b/src/skill_atlas/core/graph.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from attrs import define, field
 import json
+import hashlib
 import networkx as nx
 from typing import Any
 
@@ -50,11 +51,13 @@ class AtlasGraph:
     # ------------------------------------------------------------------
     def serialize(self) -> str:
         def _edge_key(e: Edge) -> tuple[str, str, bool, str]:
+            payload_json = json.dumps(e.payload, sort_keys=True)
+            payload_hash = hashlib.sha1(payload_json.encode()).hexdigest()
             return (
                 e.tail,
                 e.head,
                 e.directed,
-                json.dumps(e.payload, sort_keys=True),
+                payload_hash,
             )
 
         edges_sorted = sorted(self.edges(), key=_edge_key)

--- a/src/skill_atlas/core/graph.py
+++ b/src/skill_atlas/core/graph.py
@@ -49,6 +49,16 @@ class AtlasGraph:
 
     # ------------------------------------------------------------------
     def serialize(self) -> str:
+        def _edge_key(e: Edge) -> tuple[str, str, bool, str]:
+            return (
+                e.tail,
+                e.head,
+                e.directed,
+                json.dumps(e.payload, sort_keys=True),
+            )
+
+        edges_sorted = sorted(self.edges(), key=_edge_key)
+
         graph_dict = {
             "nodes": [
                 {
@@ -67,7 +77,7 @@ class AtlasGraph:
                     "directed": e.directed,
                     "payload": e.payload,
                 }
-                for e in self.edges()
+                for e in edges_sorted
             ],
         }
         return json.dumps(graph_dict, sort_keys=True)

--- a/tests/test_core_graph.py
+++ b/tests/test_core_graph.py
@@ -24,3 +24,24 @@ def test_graph_round_trip_with_abstract_node() -> None:
     assert g == new_g
     abstract_nodes = [n for n in new_g.nodes() if n.is_abstract()]
     assert len(abstract_nodes) == 1
+
+
+def test_edge_sorting_deterministic() -> None:
+    g1 = AtlasGraph()
+    g2 = AtlasGraph()
+
+    for g in (g1, g2):
+        g.add_node(Node(id="a", name="A", description=""))
+        g.add_node(Node(id="b", name="B", description=""))
+        g.add_node(Node(id="c", name="C", description=""))
+
+    edge1 = Edge(head="b", tail="a", payload={"p": 1})
+    edge2 = Edge(head="c", tail="b", payload={"p": 2})
+
+    g1.add_edge(edge1)
+    g1.add_edge(edge2)
+
+    g2.add_edge(edge2)
+    g2.add_edge(edge1)
+
+    assert g1.serialize() == g2.serialize()


### PR DESCRIPTION
## Summary
- sort edges deterministically in `AtlasGraph.serialize`
- test that graphs with different edge insertion order serialize identically

## Testing
- `ruff check .`
- `pyright`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_684f3a2a9f8483338190b0b87405c1bc