### PR TITLE
Add radial layout implementation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,8 @@ This file captures outstanding tasks and ideas for future contributors. When sub
 - [ ] Provide example configurations under `examples/`
 
 ## Layout and export
-- [ ] Implement radial and force-directed layout algorithms
+- [x] Implement radial layout algorithm
+- [ ] Implement force-directed layout algorithm
 - [ ] Provide exporters for JSON and a basic HTML visualization
 
 Feel free to add more tasks or expand the descriptions as the project evolves.

--- a/src/skill_atlas/layout/radial.py
+++ b/src/skill_atlas/layout/radial.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from math import cos, sin, tau
+from typing import Any
+
+import networkx as nx
+
+
+def radial_layout(
+    graph: nx.Graph[Any], radius: float = 1.0
+) -> dict[Any, tuple[float, float]]:
+    """Return positions for nodes arranged evenly on a circle."""
+
+    n = graph.number_of_nodes()
+    if n == 0:
+        return {}
+
+    angle_step = tau / n
+    positions: dict[Any, tuple[float, float]] = {}
+    for idx, node in enumerate(sorted(graph.nodes())):
+        angle = idx * angle_step
+        positions[node] = (radius * cos(angle), radius * sin(angle))
+    return positions

--- a/tests/test_layout_radial.py
+++ b/tests/test_layout_radial.py
@@ -1,0 +1,14 @@
+from skill_atlas.layout.radial import radial_layout
+import networkx as nx
+from typing import Any
+
+
+def test_radial_layout_positions() -> None:
+    g: nx.Graph[Any] = nx.Graph()
+    for i in range(4):
+        g.add_node(i)
+
+    positions = radial_layout(g)
+    assert len(positions) == 4
+    for pos in positions.values():
+        assert isinstance(pos[0], float) and isinstance(pos[1], float)


### PR DESCRIPTION
## Summary
- implement a simple radial layout algorithm
- add tests for the new layout helper
- check off the radial layout item in ROADMAP

## Testing
- `ruff check .`
- `ruff format --check .`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851d4f6c4848333ba52ce9736c45bba