### PR TITLE
Document undirected edge duplication

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,7 @@
+# Architecture
+
+This document describes the core design decisions of the project.
+
+## Undirected edges
+
+Undirected connections are stored only once in ``AtlasGraph._edges`` but are inserted twice into the underlying ``networkx.MultiDiGraph`` (``tail``→``head`` and ``head``→``tail``). This mirror approach keeps edge iteration stable while still letting ``NetworkX`` return neighbors in both directions. Future validators should treat the two directed edges as a single logical connection and not flag them as duplicates.

--- a/src/skill_atlas/core/graph.py
+++ b/src/skill_atlas/core/graph.py
@@ -28,6 +28,10 @@ class AtlasGraph:
     # ------------------------------------------------------------------
     def add_edge(self, edge: Edge) -> None:
         """Add ``edge`` to the graph."""
+        # Undirected edges are stored once in ``_edges`` but inserted twice into
+        # the underlying ``networkx`` graph. When ``edge.directed`` is ``False``
+        # we add both ``tail``→``head`` and ``head``→``tail`` entries so
+        # neighbor lookups behave symmetrically.
         self._g.add_edge(edge.tail, edge.head, edge=edge)  # pyright: ignore[reportUnknownMemberType]
         if not edge.directed:
             self._g.add_edge(edge.head, edge.tail, edge=edge)  # pyright: ignore[reportUnknownMemberType]

--- a/src/skill_atlas/core/graph.py
+++ b/src/skill_atlas/core/graph.py
@@ -27,11 +27,13 @@ class AtlasGraph:
 
     # ------------------------------------------------------------------
     def add_edge(self, edge: Edge) -> None:
-        """Add ``edge`` to the graph."""
-        # Undirected edges are stored once in ``_edges`` but inserted twice into
-        # the underlying ``networkx`` graph. When ``edge.directed`` is ``False``
-        # we add both ``tail``→``head`` and ``head``→``tail`` entries so
-        # neighbor lookups behave symmetrically.
+        """Add ``edge`` to the graph.
+
+        Undirected edges are stored **once** in ``self._edges`` but inserted
+        **twice** into the underlying ``networkx`` graph (``tail``→``head`` and
+        ``head``→``tail``). Validators must treat those two directed records as
+        a single logical connection.
+        """
         self._g.add_edge(edge.tail, edge.head, edge=edge)  # pyright: ignore[reportUnknownMemberType]
         if not edge.directed:
             self._g.add_edge(edge.head, edge.tail, edge=edge)  # pyright: ignore[reportUnknownMemberType]


### PR DESCRIPTION
## Summary
- document how undirected edges are represented
- clarify `AtlasGraph.add_edge` docstring about double insertion

## Testing
- `pre-commit run --files src/skill_atlas/core/graph.py docs/architecture.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851db89bf908333bcd6cea1e13c2205